### PR TITLE
Typescript leaders refactor

### DIFF
--- a/css/leaders.scss
+++ b/css/leaders.scss
@@ -1,16 +1,14 @@
 .leaderboard {
-  table {
-    border-collapse: collapse;
-    width: 40%;
-  }
+  border-collapse: collapse;
+  width: 40%;
+}
 
-  th {
-    border: 2px solid rgb(0, 0, 0);
-    text-align: left;
-  }
+.leaderboard__heading {
+  border: 2px solid rgb(0, 0, 0);
+  text-align: left;
+}
 
-  td {
-    border: 2px solid rgb(0, 0, 0);
-    text-align: right;
-  }
+.leaderboard__element {
+  border: 2px solid rgb(0, 0, 0);
+  text-align: right;
 }

--- a/leaders.html
+++ b/leaders.html
@@ -15,7 +15,31 @@
   </head>
   <body>
     <h1>Leaderboard</h1>
-    <div class="leaderboard" id="content">
-    </div>
+    <template id="leaderboard_row">
+      <tr>
+        <td class="leaderboard__element"></td>
+        <td class="leaderboard__element"></td>
+        <td class="leaderboard__element"></td>
+        <td class="leaderboard__element"></td>
+        <td class="leaderboard__element"></td>
+        <td class="leaderboard__element"></td>
+        <td class="leaderboard__element"></td>
+        <td class="leaderboard__element"></td>
+      </tr>
+    </template>
+    <table class="leaderboard" id="content">
+      <thead>
+        <tr>
+          <th class="leaderboard__heading">Name</th>
+          <th class="leaderboard__heading">Time</th>
+          <th class="leaderboard__heading">Width</th>
+          <th class="leaderboard__heading">Height</th>
+          <th class="leaderboard__heading">Mines</th>
+          <th class="leaderboard__heading">Rclicks</th>
+          <th class="leaderboard__heading">Clicks</th>
+          <th class="leaderboard__heading">Board_score</th>
+        </tr>
+      </thead>
+    </table>
   </body>
 </html>

--- a/leaders.html
+++ b/leaders.html
@@ -10,8 +10,8 @@
     <link type="image/png" rel="shortcut icon" href="images/favicon.png" />
     <link rel="stylesheet" type="text/css" href="css/leaders.css" />
     <title>Leaderboard</title>
-    <script type="application/javascript" src="lib/leaders.js">
-    </script>
+    <script type="module" src="lib/formatTime.js"></script>
+    <script type="module" src="lib/leaders.js"></script>
   </head>
   <body>
     <h1>Leaderboard</h1>

--- a/lib/leaders.ts
+++ b/lib/leaders.ts
@@ -6,44 +6,28 @@
 import { formatTime } from "./formatTime.js";
 import type { Score } from "./score";
 
-/**
- * Create an HTML table from a score object.
- * 
- * @param scores An object containing score info.
- * @returns The generated table.
- */
-function create_table(scores: Score[]): HTMLTableElement {
-	const table = document.createElement("table");
-
-	scores.sort((a, b) => a.board_score / a.time - b.board_score / b.time);
-	for (let i = 0; i < scores.length; i++) {
-		const row = table.insertRow();
-		for (const part in scores[i]) {
-			if (part === "time") {
-				row.insertCell().appendChild(document.createTextNode(formatTime(scores[i][part])));
-			} else {
-				row.insertCell().appendChild(document.createTextNode(scores[i][part].toString()));
-			}
-		}
-	}
-
-	// Inserting the header at the end takes advantage of insertRow() creating
-	// a <tbody> for us.
-	const thead = table.createTHead();
-	const header = thead.insertRow();
-	for (const part in scores[0]) {
-		const th = document.createElement("th");
-		th.appendChild(document.createTextNode(part.replace(/\b\w/g, x => x.toUpperCase())));
-		header.appendChild(th);
-	}
-
-	return table;
-}
+const $: typeof document.querySelector = document.querySelector.bind(document);
 
 document.addEventListener("DOMContentLoaded", () => {
 	const scores: Score[] = JSON.parse(localStorage.getItem("leaderboard")) ?? [];
 
-	document.getElementById("content").appendChild(create_table(scores));
+	const template = $("#leaderboard_row") as HTMLTemplateElement;
+	scores.sort((a, b) => a.board_score / a.time - b.board_score / b.time);
+	for (const row in scores) {
+		const clone = template.content.cloneNode(true) as DocumentFragment;
+		const datacells = clone.querySelectorAll(".leaderboard__element");
+
+		datacells[0].textContent = scores[row].name;
+		datacells[1].textContent = formatTime(scores[row].time);
+		datacells[2].textContent = scores[row].width.toString();
+		datacells[3].textContent = scores[row].height.toString();
+		datacells[4].textContent = scores[row].mines.toString();
+		datacells[5].textContent = scores[row].rclicks.toString();
+		datacells[6].textContent = scores[row].clicks.toString();
+		datacells[7].textContent = scores[row].board_score.toString();
+
+		$("#content").appendChild(clone);
+	}
 });
 
 /*

--- a/lib/leaders.ts
+++ b/lib/leaders.ts
@@ -4,6 +4,7 @@
  */
 
 import { formatTime } from "./formatTime";
+import type { Score } from "./score";
 
 /**
  * Create an HTML table from a score object.
@@ -11,10 +12,10 @@ import { formatTime } from "./formatTime";
  * @param scores An object containing score info.
  * @returns The generated table.
  */
-function create_table(scores: any[]): HTMLTableElement {
+function create_table(scores: Score[]): HTMLTableElement {
 	const table = document.createElement("table");
 
-	scores.sort((a, b) => a.score / a.time - b.score / b.time);
+	scores.sort((a, b) => a.board_score / a.time - b.board_score / b.time);
 	for (let i = 0; i < scores.length; i++) {
 		const row = table.insertRow();
 		for (const part in scores[i]) {
@@ -40,7 +41,7 @@ function create_table(scores: any[]): HTMLTableElement {
 }
 
 window.addEventListener("load", function () {
-	let scores = [];
+	let scores: Score[] = [];
 	const xhttp = new XMLHttpRequest();
 	xhttp.onreadystatechange = function () {
 		if (this.readyState === 4 && this.status === 200) {

--- a/lib/leaders.ts
+++ b/lib/leaders.ts
@@ -9,38 +9,35 @@ import type { Score } from "./score";
 const $: typeof document.querySelector = document.querySelector.bind(document);
 
 document.addEventListener("DOMContentLoaded", () => {
-	const scores: Score[] = JSON.parse(localStorage.getItem("leaderboard")) ?? [];
-
-	const template = $("#leaderboard_row") as HTMLTemplateElement;
-	scores.sort((a, b) => a.board_score / a.time - b.board_score / b.time);
-	for (const row in scores) {
-		const clone = template.content.cloneNode(true) as DocumentFragment;
-		const datacells = clone.querySelectorAll(".leaderboard__element");
-
-		datacells[0].textContent = scores[row].name;
-		datacells[1].textContent = formatTime(scores[row].time);
-		datacells[2].textContent = scores[row].width.toString();
-		datacells[3].textContent = scores[row].height.toString();
-		datacells[4].textContent = scores[row].mines.toString();
-		datacells[5].textContent = scores[row].rclicks.toString();
-		datacells[6].textContent = scores[row].clicks.toString();
-		datacells[7].textContent = scores[row].board_score.toString();
-
-		$("#content").appendChild(clone);
-	}
-});
-
-/*
-window.addEventListener("load", function () {
-	let scores: Score[] = [];
+	let scores: Score[];
 	const xhttp = new XMLHttpRequest();
-	xhttp.onreadystatechange = function () {
-		if (this.readyState === 4 && this.status === 200) {
-			scores = JSON.parse(this.responseText);
-			document.getElementById("content").appendChild(create_table(scores));
+
+	xhttp.addEventListener("load", () => {
+		if (xhttp.status === 200) {
+			scores = JSON.parse(xhttp.responseText) ?? [];
+		} else {
+			scores = JSON.parse(localStorage.getItem("leaderboard")) ?? [];
 		}
-	};
+
+		const template = $("#leaderboard_row") as HTMLTemplateElement;
+		scores.sort((a, b) => a.board_score / a.time - b.board_score / b.time);
+		for (const row in scores) {
+			const clone = template.content.cloneNode(true) as DocumentFragment;
+			const datacells = clone.querySelectorAll(".leaderboard__element");
+
+			datacells[0].textContent = scores[row].name;
+			datacells[1].textContent = formatTime(scores[row].time);
+			datacells[2].textContent = scores[row].width.toString();
+			datacells[3].textContent = scores[row].height.toString();
+			datacells[4].textContent = scores[row].mines.toString();
+			datacells[5].textContent = scores[row].rclicks.toString();
+			datacells[6].textContent = scores[row].clicks.toString();
+			datacells[7].textContent = scores[row].board_score.toString();
+
+			$("#content").appendChild(clone);
+		}
+	});
+
 	xhttp.open("GET", "leaderboard.json", true);
 	xhttp.send();
 });
-*/

--- a/lib/leaders.ts
+++ b/lib/leaders.ts
@@ -40,6 +40,13 @@ function create_table(scores: Score[]): HTMLTableElement {
 	return table;
 }
 
+document.addEventListener("DOMContentLoaded", () => {
+	const scores: Score[] = JSON.parse(localStorage.getItem("leaderboard")) ?? [];
+
+	document.getElementById("content").appendChild(create_table(scores));
+});
+
+/*
 window.addEventListener("load", function () {
 	let scores: Score[] = [];
 	const xhttp = new XMLHttpRequest();
@@ -52,3 +59,4 @@ window.addEventListener("load", function () {
 	xhttp.open("GET", "leaderboard.json", true);
 	xhttp.send();
 });
+*/

--- a/lib/leaders.ts
+++ b/lib/leaders.ts
@@ -3,7 +3,7 @@
  * @author Aiden Woodruff
  */
 
-import { formatTime } from "./formatTime";
+import { formatTime } from "./formatTime.js";
 import type { Score } from "./score";
 
 /**

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -1,0 +1,18 @@
+/**
+ * @file Leaderboard score entry schema.
+ * @author Aiden Woodruff
+ */
+
+/**
+ * Score entry.
+ */
+export interface Score {
+	name: string;
+	time: number;
+	width: number;
+	height: number;
+	mines: number;
+	rclicks: number;
+	clicks: number;
+	board_score: number;
+}

--- a/lib/sweeper.ts
+++ b/lib/sweeper.ts
@@ -334,7 +334,7 @@ window.onload = function () {
 
 	score_entry.height = params.height;
 	score_entry.width = params.width;
-	score_entry.mines = params.width;
+	score_entry.mines = params.mines;
 	score_entry.clicks = 0;
 	score_entry.rclicks = 0;
 

--- a/lib/sweeper.ts
+++ b/lib/sweeper.ts
@@ -221,6 +221,30 @@ function flag(event: MouseEvent): boolean {
  * Send an XHR to ud_leaderboard.php file.
  */
 function update_leaderboard() {
+	const leaderboard: Score[] = JSON.parse(localStorage.getItem("leaderboard")) ?? [];
+
+	score_entry.name = $("#name").value;
+	leaderboard.push(score_entry);
+
+	try {
+		localStorage.setItem("leaderboard", JSON.stringify(leaderboard));
+		const ld = document.createElement("a");
+		ld.href = "leaders.html";
+		ld.innerHTML = "Leaderboard";
+		while (document.getElementById("end").firstChild) {
+			document.getElementById("end").removeChild(document.getElementById("end").firstChild);
+		}
+		document.getElementById("end").appendChild(ld);
+	} catch (e) {
+		console.log("Couldn't update leaderboard.");
+		while (document.getElementById("end").firstChild) {
+			document.getElementById("end").removeChild(document.getElementById("end").firstChild);
+		}
+		const error_msg = document.createElement("p");
+		error_msg.innerHTML = "Leaderboard doesn't work here.";
+		document.getElementById("end").appendChild(error_msg);
+	}
+	/*
 	const xhttp = new XMLHttpRequest();
 	xhttp.onreadystatechange = function () {
 		if (this.status === 405) {
@@ -248,6 +272,7 @@ function update_leaderboard() {
 	
 	score_entry.name = $("#name").value;
 	xhttp.send(JSON.stringify(score_entry));
+	*/
 }
 
 /**

--- a/lib/sweeper.ts
+++ b/lib/sweeper.ts
@@ -16,7 +16,16 @@ let minecount: HTMLParagraphElement;
 let timer: number | undefined = undefined; // Not sure what values are never accepted by window.clearInterval, so just use undefined
 let minefield: MineField;
 let params: {width: number, height: number, mines: number};
-let score_entry: Score;
+const score_entry: Score = {
+	name: "",
+	time: 0,
+	width: -1,
+	height: -1,
+	mines: -1,
+	rclicks: 0,
+	clicks: 0,
+	board_score: -1
+};
 
 /**
  * Extract coordinates from \<td\>.

--- a/lib/sweeper.ts
+++ b/lib/sweeper.ts
@@ -221,58 +221,48 @@ function flag(event: MouseEvent): boolean {
  * Send an XHR to ud_leaderboard.php file.
  */
 function update_leaderboard() {
-	const leaderboard: Score[] = JSON.parse(localStorage.getItem("leaderboard")) ?? [];
-
 	score_entry.name = $("#name").value;
-	leaderboard.push(score_entry);
 
-	try {
-		localStorage.setItem("leaderboard", JSON.stringify(leaderboard));
+	const replace_link = () => {
 		const ld = document.createElement("a");
 		ld.href = "leaders.html";
-		ld.innerHTML = "Leaderboard";
-		while (document.getElementById("end").firstChild) {
-			document.getElementById("end").removeChild(document.getElementById("end").firstChild);
-		}
-		document.getElementById("end").appendChild(ld);
-	} catch (e) {
-		console.log("Couldn't update leaderboard.");
-		while (document.getElementById("end").firstChild) {
-			document.getElementById("end").removeChild(document.getElementById("end").firstChild);
-		}
-		const error_msg = document.createElement("p");
-		error_msg.innerHTML = "Leaderboard doesn't work here.";
-		document.getElementById("end").appendChild(error_msg);
-	}
-	/*
-	const xhttp = new XMLHttpRequest();
-	xhttp.onreadystatechange = function () {
-		if (this.status === 405) {
-			console.log("Couldn't update leaderboard.");
-			while (document.getElementById("end").firstChild) {
-				document.getElementById("end").removeChild(document.getElementById("end").firstChild);
-			}
-			const error_msg = document.createElement("p");
-			error_msg.innerHTML = "Leaderboard doesn't work here.";
-			document.getElementById("end").appendChild(error_msg);
-		} else if (this.readyState === 4 && this.status !== 200) {
-			console.log("There was some error updating the leaderboard.");
-		} else if (this.readyState === 4 && this.status === 200) {
-			const ld = document.createElement("a");
-			ld.href = "leaders.html";
-			ld.innerHTML = "Leaderboard";
-			while (document.getElementById("end").firstChild) {
-				document.getElementById("end").removeChild(document.getElementById("end").firstChild);
-			}
-			document.getElementById("end").appendChild(ld);
-		}
+		ld.textContent = "Leaderboard";
+		while ($("#end").firstChild) $("#end").removeChild($("#end").firstChild);
+		$("#end").appendChild(ld);
 	};
+
+	const xhttp = new XMLHttpRequest();
+	xhttp.addEventListener("load", () => {
+		if (xhttp.status === 200) {
+			replace_link();
+		} else {
+			const leaderboard: Score[] = JSON.parse(localStorage.getItem("leaderboard")) ?? [];
+
+			leaderboard.push(score_entry);
+
+			try {
+				localStorage.setItem("leaderboard", JSON.stringify(leaderboard));
+				replace_link();
+			} catch (e) {
+				if (e instanceof DOMException
+					&& (e.name === "QuotaExceededError" || e.code === 22)) {
+					while ($("#end").firstChild) {
+						$("#end").removeChild($("#end").firstChild);
+					}
+					const error_msg = document.createElement("p");
+					error_msg.textContent = "Leaderboard doesn't work here.";
+					$("#end").appendChild(error_msg);
+				} else {
+					throw e;
+				}
+			}
+		}
+	});
+
 	xhttp.open("POST", "ud_leaderboard.php", true);
 	xhttp.setRequestHeader("Content-Type", "application/json");
 	
-	score_entry.name = $("#name").value;
 	xhttp.send(JSON.stringify(score_entry));
-	*/
 }
 
 /**


### PR DESCRIPTION
- [x] Add typescript type/interface for leaderboard object
- [x] Add `<template>` to leaders.html
- [x] Store data in localStorage even if server file doesn't work
- [x] Maintain final output

Due to the original issue requesting both equal output and a finalized schema, cleaning up extraneous properties was left for a later time (see #16). This decision was based on the issue being a refactor rather than an actual update (and it's part of the typescript refactor).